### PR TITLE
feat: adds default email OIDC fallback

### DIFF
--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -82,7 +82,7 @@ func (o *OIDC) ExchangeCode(redirectURI, code string) (string, error) {
 }
 
 // GetUser uses the given token and returns a complete provider.User object
-func (o *OIDC) GetUser(token, UserPath string) (string, error) {
+func (o *OIDC) GetUser(token, userPath string) (string, error) {
 	// Parse & Verify ID Token
 	idToken, err := o.verifier.Verify(o.ctx, token)
 	if err != nil {
@@ -95,8 +95,11 @@ func (o *OIDC) GetUser(token, UserPath string) (string, error) {
 		return "", err
 	}
 
-	if claims[UserPath] == nil {
-		return "", fmt.Errorf("no such user path: '%s' in the Claims", UserPath)
+	if user, ok := claims[userPath].(string); ok {
+		return user, nil
 	}
-	return claims[UserPath].(string), nil
+	if email, ok := claims["email"].(string); ok {
+		return email, nil
+	}
+	return "", fmt.Errorf("no such user path: '%s' or 'email' in the claims", userPath)
 }

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -150,6 +150,29 @@ func TestOIDCGetUserCustom(t *testing.T) {
 	assert.Equal("customValue", user)
 }
 
+func TestOIDCGetUserCustomFallback(t *testing.T) {
+	assert := assert.New(t)
+
+	provider, server, serverURL, key := setupOIDCTest(t, nil)
+	defer server.Close()
+
+	// Generate JWT
+	token := key.sign(t, []byte(`{
+		"iss": "`+serverURL.String()+`",
+		"exp":`+strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)+`,
+		"aud": "idtest",
+		"sub": "1",
+		"email": "example@example.com",
+		"email_verified": true,
+		"customField": "customValue"
+	}`))
+
+	// Get user
+	user, err := provider.GetUser(token, "fieldDoesNotExist")
+	assert.Nil(err)
+	assert.Equal("example@example.com", user)
+}
+
 // Utils
 
 // setOIDCTest creates a key, OIDCServer and initilises an OIDC provider


### PR DESCRIPTION
If the specified UserField cannot be found in the OIDC claim, then the default 'email' field will be returned.